### PR TITLE
install: Change shim installation to /usr/libexec/clear-containers

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -23,7 +23,7 @@ set -e
 autoreconf --force --install --symlink --warnings=all
 
 args="\
---prefix=/usr"
+--prefix=/usr --libexecdir=/usr/libexec/clear-containers"
 
 set -x
 ./configure $args "$@"


### PR DESCRIPTION
The shim binary was being installed under /usr/libexec.
Change this to /usr/libexec/clear-containers for consistency
and to not conflict with 2.1 binary.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>