### PR TITLE
travis: Fix the build for coverity scan.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
       name: "clearcontainers/shim"
       description: "Build submitted via Travis CI"
     notification_email: archana.m.shinde@intel.com
-    build_command_prepend: "./configure; make clean"
+    build_command_prepend: "./autogen.sh; make clean"
     build_command:   "make -j 4"
     branch_pattern: coverity_scan
 


### PR DESCRIPTION
Run autogen.sh script before make for the branch used
for coverity scans

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>