### PR TITLE
stdin: Make sure that the buffer read from stdin is NULL terminated

### DIFF
--- a/src/shim.c
+++ b/src/shim.c
@@ -529,7 +529,7 @@ handle_stdin(struct cc_shim *shim)
 		return;
 	}
 
-	nread = read(STDIN_FILENO , buf, BUFSIZ);
+	nread = read(STDIN_FILENO , buf, BUFSIZ-1);
 	if (nread < 0) {
 		shim_warning("Error while reading stdin char :%s\n", strerror(errno));
 		return;


### PR DESCRIPTION
Read one less byte from stdin to make sure the buffer is NULL
terminated.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>