### PR TITLE
signals: Change the json passed to what the proxy expects

### DIFF
--- a/mock/mock_proxy.go
+++ b/mock/mock_proxy.go
@@ -105,9 +105,9 @@ type ConnectShim struct {
 
 // ShimSignal is the struct used to represent the signal received from the shim
 type ShimSignal struct {
-	Signal int `json:"signal"`
-	Row    int `json:"row,omitempty"`
-	Column int `json:"column,omitempty"`
+	Signal int `json:"signalNumber"`
+	Row    int `json:"rows,omitempty"`
+	Column int `json:"columns,omitempty"`
 }
 
 func connectShimHandler(data []byte, userData interface{}, response *handlerResponse) {

--- a/src/shim.c
+++ b/src/shim.c
@@ -485,17 +485,17 @@ handle_signals(struct cc_shim *shim) {
 					strerror(errno));
 				continue;
 			}
-			ret = asprintf(&payload, "{\"signal\": %d,"\
-					" \"row\":%d, \"column\":%d}",
+			ret = asprintf(&payload, "{\"signalNumber\": %d,"\
+					" \"rows\":%d, \"columns\":%d}",
 					 sig, ws.ws_row, ws.ws_col);
 
 			shim_debug("handled SIGWINCH for container %s "
-				"(row=%d, column=%d)\n",
+				"(rows=%d, columns=%d)\n",
 				shim->container_id? shim->container_id: "",
 				ws.ws_row, ws.ws_col);
 
 		} else {
-			ret = asprintf(&payload, "{\"signal\":%d}",
+			ret = asprintf(&payload, "{\"signalNumber\":%d}",
                                                          sig);
 			shim_debug("Sending signal %d to container %s\n",
 				sig,


### PR DESCRIPTION
The json expected by the proxy for signal handling changed in
the new implementation. Sync the changes as the signal handling
was implemented before the protocol was fully defined and
changes were not synced.

The payload api from the proxy should be probably be vendored
in the mock proxy now, to be done in a separate commit.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>