### PR TITLE
fix gcc warnings

### DIFF
--- a/src/shim.c
+++ b/src/shim.c
@@ -599,8 +599,8 @@ void
 handle_proxy_stream(struct cc_shim *shim, struct frame *fr)
 {
 	int outfd = -1;
-	ssize_t offset = 0;
-	size_t ret;
+	size_t offset = 0;
+	ssize_t ret;
 
 	if (! (shim && shim->proxy_address)) {
 		return;
@@ -622,13 +622,13 @@ handle_proxy_stream(struct cc_shim *shim, struct frame *fr)
 
 	while (offset < fr->header.payload_len) {
 		ret = write(outfd, fr->payload + offset,
-				 (size_t)(fr->header.payload_len - offset));
+				 (fr->header.payload_len - offset));
 		if (ret <= 0 ) {
 			shim_error("Could not write stream to fd %d for proxy %s: %s\n",
 					outfd, shim->proxy_address, strerror(errno));
 			return;
 		}
-		offset += (ssize_t)ret;
+		offset += (size_t)ret;
 	}
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -128,8 +128,8 @@ verify_base64url_format(char *s)
 	 *
 	 * See: https://tools.ietf.org/html/rfc4648#section-4
 	 */
-	ret = asprintf(&regex, "^(%1$s{4})*(%1$s{4}|%1$s{3}=|%1$s{2}==)$",
-				alph_set);
+	ret = asprintf(&regex, "^(%s{4})*(%s{4}|%s{3}=|%s{2}==)$",
+				alph_set, alph_set, alph_set, alph_set);
 
 	if ( !regex) {
 		abort();


### PR DESCRIPTION
Fix two compile warnings:

1. write() returns ssize_t (negative value for error).
2. %n$ is posix extension, not supported by C99.

Signed-off-by: WANG Chao <chao.wang@ucloud.cn>