### PR TITLE
log: Do not log to stderr

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -28,7 +28,7 @@ static bool debug;
  */
 void shim_log_init(bool _debug)
 {
-	int syslog_options = (LOG_CONS | LOG_PID | LOG_PERROR | LOG_NOWAIT);
+	int syslog_options = (LOG_PID | LOG_NOWAIT);
 
 	debug = _debug;
 	openlog(0, syslog_options, LOG_USER);


### PR DESCRIPTION
With this change, debug, info and warning log messages will
not be logged to stderr when debug is enabled, these will just
be sent to syslog.
Only error messages will be logged to stderr.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>