### PR TITLE
Cleanup CONTRUBING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to clearcontainers/shim
 
-clearcontainers/shim is an open source project licensed under the [Apache License] (https://www.apache.org/licenses/LICENSE-2.0).
+clearcontainers/shim is an open source project licensed under the [Apache License](https://www.apache.org/licenses/LICENSE-2.0).
 
 ## Coding Style
 
@@ -32,7 +32,7 @@ The right results can be almost achieved by doing the following.
 
 ## Certificate of Origin
 
-In order to get a clear contribution chain of trust we use the [signed-off-by language] (https://01.org/community/signed-process)
+In order to get a clear contribution chain of trust we use the [signed-off-by language](https://01.org/community/signed-process)
 used by the Linux kernel project.
 
 ## Patch format
@@ -70,21 +70,21 @@ It is recommended that each of your patches fixes one thing. Smaller patches are
 
 ## Pull requests
 
-We accept [github pull requests] (https://github.com/clearcontainers/shim/pulls).
+We accept [github pull requests](https://github.com/clearcontainers/shim/pulls).
 
-Github has a basic introduction to the process [here] (https://help.github.com/articles/using-pull-requests/).
+Github has a basic introduction to the process [here](https://help.github.com/articles/using-pull-requests/).
 
 When submitting your Pull Request (PR), treat the Pull Request message the same you would a patch message, including pre-fixing the title with a subsystem name. Github by default seems to copy the message from your first patch, which many times is appropriate, but please ensure your message is accurate and complete for the whole Pull Request, as it ends up in the git log as the merge message.
 
 Your pull request may get some feedback and comments, and require some rework. The recommended procedure for reworking is to rework your branch to a new clean state and 'force push' it to your github. GitHub understands this action, and does sensible things in the online comment history. Do not pile patches on patches to rework your branch. Any relevant information from the github comments section should be re-worked into your patch set, as the ultimate place where your patches are documented is in the git log, and not in the github comments section.
 
-For more information on github 'force push' workflows see [here] (http://blog.adamspiers.org/2015/03/24/why-and-how-to-correctly-amend-github-pull-requests/).
+For more information on github 'force push' workflows see [here](http://blog.adamspiers.org/2015/03/24/why-and-how-to-correctly-amend-github-pull-requests/).
 
 It is perfectly fine for your Pull Request to contain more than one patch - use as many patches as you need to implement the Request (see the previously mentioned 'small patch' thoughts). Each Pull Request should only cover one topic - if you mix up different items in your patches or pull requests then you will most likely be asked to rework them.
 
 ## Reviews
 
-Before your Pull Requests are merged into the main code base, they will be reviewed. Anybody can review any Pull Request and leave feedback (in fact, it is encouraged), but this project runs a rotational GateKeeper schedule for who is ultimately responsible for merging the Pull Requests into the main code base. See [here] (https://github.com/01org/cc-oci-runtime/wiki/GateKeeper-Schedule).
+Before your Pull Requests are merged into the main code base, they will be reviewed. Anybody can review any Pull Request and leave feedback (in fact, it is encouraged), but this project runs a rotational GateKeeper schedule for who is ultimately responsible for merging the Pull Requests into the main code base. See [here](https://github.com/01org/cc-oci-runtime/wiki/GateKeeper-Schedule).
 
 We use an 'acknowledge' system for people to note if they agree, or disagree, with a Pull Request. We utilise some automated systems that can spot common acknowledge patterns, which include placing any of these at the beginning of a comment line:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,8 @@ Beside the signed-off-by footer, we expect each patch to comply with the followi
        for some more good advice, and the Linux Kernel document:
            https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/SubmittingPatches
 
+       Fixes: #nnn
+
        Signed-off-by: <contributor@foo.com>
 ```
 
@@ -59,6 +61,8 @@ For example:
     
         Change the add_pollfd function to add file descriptors at
         predefined index for maintainability.
+
+        Fixes: #123
     
         Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>
 
@@ -122,8 +126,8 @@ visibility on the problem and work toward resolution.
 
 ## Closing issues
 
-You can either close issues manually by adding the fixing commit SHA1 to the issue
-comments or by adding the `Fixes` keyword to your commit message:
+The preferred way to close issues is by adding the `Fixes` keyword to your commit message.
+If your PR contains multiple commits then only one `Fixes` is required to be present the series, but multiple may be present if necessary.
 
 ```
 Fix handling of semvers with only a single pre-release field

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,19 +76,19 @@ It is recommended that each of your patches fixes one thing. Smaller patches are
 
 We accept [github pull requests](https://github.com/clearcontainers/shim/pulls).
 
-Github has a basic introduction to the process [here](https://help.github.com/articles/using-pull-requests/).
+Github has a basic introduction to [using pull requests](https://help.github.com/articles/using-pull-requests/).
 
 When submitting your Pull Request (PR), treat the Pull Request message the same you would a patch message, including pre-fixing the title with a subsystem name. Github by default seems to copy the message from your first patch, which many times is appropriate, but please ensure your message is accurate and complete for the whole Pull Request, as it ends up in the git log as the merge message.
 
 Your pull request may get some feedback and comments, and require some rework. The recommended procedure for reworking is to rework your branch to a new clean state and 'force push' it to your github. GitHub understands this action, and does sensible things in the online comment history. Do not pile patches on patches to rework your branch. Any relevant information from the github comments section should be re-worked into your patch set, as the ultimate place where your patches are documented is in the git log, and not in the github comments section.
 
-For more information on github 'force push' workflows see [here](http://blog.adamspiers.org/2015/03/24/why-and-how-to-correctly-amend-github-pull-requests/).
+For more information on github 'force push' workflows see this [blog post](http://blog.adamspiers.org/2015/03/24/why-and-how-to-correctly-amend-github-pull-requests/).
 
 It is perfectly fine for your Pull Request to contain more than one patch - use as many patches as you need to implement the Request (see the previously mentioned 'small patch' thoughts). Each Pull Request should only cover one topic - if you mix up different items in your patches or pull requests then you will most likely be asked to rework them.
 
 ## Reviews
 
-Before your Pull Requests are merged into the main code base, they will be reviewed. Anybody can review any Pull Request and leave feedback (in fact, it is encouraged), but this project runs a rotational GateKeeper schedule for who is ultimately responsible for merging the Pull Requests into the main code base. See [here](https://github.com/01org/cc-oci-runtime/wiki/GateKeeper-Schedule).
+Before your Pull Requests are merged into the main code base, they will be reviewed. Anybody can review any Pull Request and leave feedback (in fact, it is encouraged).
 
 We use an 'acknowledge' system for people to note if they agree, or disagree, with a Pull Request. We utilise some automated systems that can spot common acknowledge patterns, which include placing any of these at the beginning of a comment line:
 
@@ -127,7 +127,7 @@ visibility on the problem and work toward resolution.
 ## Closing issues
 
 The preferred way to close issues is by adding the `Fixes` keyword to your commit message.
-If your PR contains multiple commits then only one `Fixes` is required to be present the series, but multiple may be present if necessary.
+If your PR contains multiple commits then only one `Fixes` is required to be present in the series, but multiple may be present if necessary.
 
 ```
 Fix handling of semvers with only a single pre-release field


### PR DESCRIPTION
Clean up and enhance the CONTRIBUTING file:
 - some links had broken when github tightened its markdown requirements
 - add some details around the requirement of 'Fixes' lines in PR commit series