### PR TITLE
connect: Try to re-connect to proxy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,4 +61,10 @@ AS_IF([test $CPPCHECK = 1],
    AC_SUBST(CPPCHECK_PATH)]
 )
 
+AC_ARG_WITH([timeout], [AS_HELP_STRING([--with-timeout],
+            [reconnection timeout to proxy in seconds])])
+AS_IF([test x"$with_timeout" != "x"],
+      [AC_DEFINE_UNQUOTED([RECONNECT_TIMEOUT_S], [$with_timeout],
+                          [reconnection timeout to proxy in seconds])])
+
 AC_OUTPUT

--- a/src/shim.h
+++ b/src/shim.h
@@ -14,6 +14,8 @@
 
 #include <stdio.h>
 
+#define PROXY "cc-proxy"
+
 /* The shim would be handling fixed number of predefined fds.
  * This would be signal fd, stdin fd and a proxy socket connection fd.
  */
@@ -23,6 +25,7 @@ struct cc_shim {
 	char       *container_id;
 	int         proxy_sock_fd;
 	char       *token;
+	int        timeout;		/* reconnection timeout to proxy */
 	char       *proxy_address;
 	int         proxy_port;
 };


### PR DESCRIPTION
Try to re-connect to proxy if connection is lost (e.g. proxy died)
with RECONNECT_TIMEOUT_S timeout.

This patch is needed to implement high availability of cc-proxy.

Fixes #53.

Signed-off-by: Dmitry Voytik <dmitry.voytik@huawei.com>