### PR TITLE
CI: Remove user as project approver

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -34,7 +34,6 @@ groups:
     required: 1
     users:
       - amshinde
-      - dlespiau
       - grahamwhaley
       - mcastelino
       - sameo

--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@ reviewers:
 
 approvers:
 - amshinde
-- dlespiau
 - grahamwhaley
 - mcastelino
 - sameo


### PR DESCRIPTION
Remove user dlespiau as a project approver as he is no longer a core
maintainer.

Fixes #55.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>