### PR TITLE
build: Create m4 directory to avoid warning

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -20,6 +20,7 @@
 
 set -e
 
+mkdir -p m4
 autoreconf --force --install --symlink --warnings=all
 
 args="\


### PR DESCRIPTION
Create the `m4` directory to avoid `aclocal` complaining that it
doesn't exist.

Fixes #66.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>