### PR TITLE
signal: Remove depecrated signal constant SIGUNUSED

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -64,7 +64,9 @@ int shim_signal_table[] = {
 	SIGIO,               /* I/O now possible */
 	SIGPWR,              /* Power failure restart */
 	//SIGSYS,            /* Bad system call */
+#ifdef SIGUNUSED
 	SIGUNUSED,
+#endif
 	0,
 };
 


### PR DESCRIPTION
With glibc 2.6, the obsolete signal constant SIGUNUSED is no longer
defined by signal.h.

Fixes #68

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>