### PR TITLE
CI: remove tests from run.sh script

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -18,47 +18,7 @@
 
 set -e
 
-# Current docker tests:
-# TODO: Move these docker commands to more formal tests in 
-# `clearcontainers/tests` repository. See issue: 
-# https://github.com/clearcontainers/tests/issues/59
-container_id=$(sudo docker create busybox /bin/sleep 60)
-sudo docker ps -a
-sudo docker start ${container_id}
-sudo docker ps -a
-sudo docker exec ${container_id} echo hello
-sudo docker ps -a
-
-# try to unpause a container that isn't paused a few times
-tmpfile=$(mktemp)
-for i in 1 2 3
-do
-	{ sudo docker unpause ${container_id} &>"$tmpfile"; ret=$?; } || true
-	[ $ret -eq 0 ] && { cat "$tmpfile"; exit 1; }
-done
-
-sudo docker pause ${container_id}
-sudo docker inspect ${container_id}|grep -qi "\"Paused\":.*true"
-
-# try to pause an already paused container a few times
-for i in 1 2 3
-do
-	{ sudo docker pause ${container_id} &>"$tmpfile"; ret=$?; } || true
-	[ $ret -eq 0 ] && { cat "$tmpfile"; exit 1; }
-done
-
-rm -f "$tmpfile"
-
-sudo docker unpause ${container_id}
-sudo docker inspect ${container_id}|grep -qi "\"Paused\":.*false"
-
-sudo docker ps -a
-sudo docker stop ${container_id}
-sudo docker ps -a
-sudo docker rm ${container_id}
-sudo docker ps -a
-
 # Execute the tests under `clearcontainers/tests` repository.
 test_repo="github.com/clearcontainers/tests"
 cd "${GOPATH}/src/${test_repo}"
-sudo -E PATH=$PATH make check
+.ci/run.sh


### PR DESCRIPTION
The run.sh script has docker tests that are already
covered by our testsuite in the tests repository.
This commit removes those tests.

This commit also changes the way the tests are called in
the tests repository to allow execute OpenShift tests if
the OPENSHIFT_CI envar is set to true.

Fixes: #80.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>