### PR TITLE
logging: Use structured logging

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,8 @@ ACLOCAL_AMFLAGS = -I m4
 # Has a value if building in a git tree
 GIT_COMMIT := $(shell git rev-parse HEAD 2>/dev/null)
 
+TARGET = cc-shim
+
 # Has a value if building in a git-archive(1)-generated tree
 # (see .gitattributes).
 GENERATED_COMMIT = $(shell cat commit_id.fmt 2>/dev/null \| grep \'^[a-f0-9][a-f0-9]*\$\')
@@ -47,9 +49,10 @@ AM_LDFLAGS = -pie -z noexecstack -z relro -z now
 AM_CPPFLAGS = -D_FORTIFY_SOURCE=2 \
 		-DGIT_COMMIT=\"$(STORED_COMMIT)\"
 
-libexec_PROGRAMS = cc-shim
+libexec_PROGRAMS = $(TARGET)
 
 cc_shim_CFLAGS = \
+	-DSHIM_NAME="\"$(TARGET)\"" \
 	$(AM_CFLAGS)
 
 cc_shim_SOURCES = \

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,6 +15,15 @@
 #pragma once
 
 #include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Minimum size of buffer required to pass to get_time_iso8601() to allow it
+ * to display a time in ISO 8601 format (+1 for terminator):
+ *
+ *     2006-01-02T15:04:05.999999999-0700
+ */
+#define SHIM_TIME_BUFFER_SIZE (34+1)
 
 extern int shim_signal_table[];
 
@@ -27,3 +36,5 @@ void set_big_endian_32(uint8_t *buf, uint32_t val);
 uint32_t get_big_endian_32(const uint8_t *buf);
 void set_big_endian_64(uint8_t *buf, uint64_t val);
 uint64_t get_big_endian_64(const uint8_t *buf);
+int get_time_iso8601(char *buffer, size_t size);
+char *quote_string(const char *str);


### PR DESCRIPTION
Make the shim log messages in the logfmt format for parity with the
other system components.

Fixes #83.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>