### PR TITLE
logging: Fix odd log message

### DIFF
--- a/src/shim.c
+++ b/src/shim.c
@@ -1248,7 +1248,7 @@ main(int argc, char **argv)
 			 * let's send SIGKILL to the process inside the VM
 			 */
 			shim_debug("Parent has terminated because of SIGKILL"
-				"/nForwarding the SIGKILL to the container"
+				" - forwarding the SIGKILL to the container"
 				" process");
 
 			signal_handler(SIGKILL);


### PR DESCRIPTION
Correct a log message which contained "/n". This might have been meant
to be "\n", but we don't want multi-line log messages so join the
message elements with a hyphen.

Fixes #91.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>