### PR TITLE
CI: Don't require an issue for release PRs

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -37,6 +37,7 @@ then
         --need-sign-offs \
         --body-length 72 \
         --subject-length 75 \
+	--ignore-fixes-for-subsystem "release" \
         --verbose
 
     # Travis doesn't provide a VT-x environment, so nothing more to do


### PR DESCRIPTION
Change the `checkcommits` config to not require an issue for release
PRs.

Fixes #119.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>