### PR TITLE
mock: Extend proxy mock to be used by virtcontainers

### DIFF
--- a/mock/protocol.go
+++ b/mock/protocol.go
@@ -29,6 +29,7 @@ type protocolHandler func([]byte, interface{}, *handlerResponse)
 type handlerResponse struct {
 	err     error
 	results map[string]interface{}
+	data    []byte
 }
 
 // SetError indicates sets error for the response.
@@ -52,6 +53,10 @@ func (r *handlerResponse) AddResult(key string, value interface{}) {
 		r.results = make(map[string]interface{})
 	}
 	r.results[key] = value
+}
+
+func (r *handlerResponse) SetData(data []byte) {
+	r.data = data
 }
 
 // FrameKey is a struct composed of the the frame type and opcode,


### PR DESCRIPTION
This proxy mock is very useful and needed to be extended regarding
the handlers provided. Indeed, in case of virtcontainers, we need
to send commands like RegisterVM, UnregisterVM, AttachVM, or even
Hyper. This patch takes care of adding appropriate handlers for
those commands.

Fixes #122

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>